### PR TITLE
Parallel work on metadata based downloads & embedding generation

### DIFF
--- a/build.py
+++ b/build.py
@@ -240,6 +240,8 @@ def parse_dev(version, download, version_update, prev_metadata):
                            and key not in ignored_sources]
         if static_download:
             subprocess.run(["./setup_data.sh", "/data/nedrex_files"])
+        else:
+            print("Static sources are already up-to-date")
         downloaders.download_all(ignored_sources=ignored_sources,
                                  no_download_meta=no_download)
 

--- a/build.py
+++ b/build.py
@@ -8,6 +8,7 @@ import nedrexdb
 from nedrexdb import config, downloaders
 from nedrexdb.control.docker import NeDRexDevInstance, NeDRexLiveInstance
 from nedrexdb.db import MongoInstance, mongo_to_neo, collection_stats
+from nedrexdb.db.import_embeddings import fetch_embeddings, upsert_embeddings
 from nedrexdb.db.parsers import (
     biogrid,
     disgenet,
@@ -77,10 +78,14 @@ def update(conf, download, version_update, create_embeddings):
 
     dev_instance = NeDRexDevInstance()
     dev_instance.remove()
+
+    # fetch embeddings from previous database
     if create_embeddings:
         dev_instance.set_up(use_existing_volume=True, neo4j_mode="db")
-
+        embeddings = fetch_embeddings()
+        print([(entry[0], entry[1][1]) for entry in embeddings][:5])
         dev_instance.remove()
+
     dev_instance.set_up(use_existing_volume=False, neo4j_mode="import")
     MongoInstance.connect("dev")
     MongoInstance.set_indexes()

--- a/build.py
+++ b/build.py
@@ -95,11 +95,16 @@ def update(conf, download, version_update, create_embeddings):
             with open("/data/nedrex_files/nedrex_data/fallback_version", "w") as fallback_file:
                 fallback_file.write(f"{nedrex_versions['version']}")
 
-            # do the download
             print("Download: ON")
             current_metadata = nedrex_versions["source_databases"]
-            subprocess.run(["./setup_data.sh", "/data/nedrex_files"])
-            downloaders.download_all(prev_metadata=prev_metadata, current_metadata=current_metadata)
+            # already up-to-date data
+            no_download = [key for key in prev_metadata if key in current_metadata and
+                           prev_metadata[key] == current_metadata[key]]
+            static_download = [key for key in ["bioontology", "drugbank", "disgenet", "repotrial"] if
+                               key not in no_download]
+            if static_download:
+                subprocess.run(["./setup_data.sh", "/data/nedrex_files"])
+            downloaders.download_all(no_download_meta=no_download)
 
         if version_update:
             get_versions(version_update)
@@ -226,13 +231,17 @@ def parse_dev(version, download, version_update, prev_metadata):
         with open("/data/nedrex_files/nedrex_data/fallback_version", "w") as fallback_file:
             fallback_file.write(f"{nedrex_versions['version']}")
 
-        # do the download
         print("Download: ON")
         current_metadata = nedrex_versions["source_databases"]
-        subprocess.run(["./setup_data.sh", "/data/nedrex_files"])
+        # already up-to-date data
+        no_download = [key for key in prev_metadata if key in current_metadata and
+                       prev_metadata[key] == current_metadata[key]]
+        static_download = [key for key in ["bioontology", "drugbank", "disgenet", "repotrial"] if key not in no_download
+                           and key not in ignored_sources]
+        if static_download:
+            subprocess.run(["./setup_data.sh", "/data/nedrex_files"])
         downloaders.download_all(ignored_sources=ignored_sources,
-                                 prev_metadata=prev_metadata,
-                                 current_metadata=current_metadata)
+                                 no_download_meta=no_download)
 
     if version_update:
         get_versions(version_update)

--- a/launch_docker.sh
+++ b/launch_docker.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/bash
 
+# add c as a cmd option without argument.
+while getopts c name
+do
+        case $name in
+          c)no_cache=1;;
+          *)echo "Invalid arg $name";;
+        esac
+done
+
 docker network create nedrexdb_default
-docker compose -f docker-compose.dev.yml build
+
+# decide whether to use cache or not
+if [[ ! -z $no_cache ]]
+then
+  docker compose -f docker-compose.dev.yml build --no-cache
+else
+  docker compose -f docker-compose.dev.yml build
+fi
+
 docker compose -f docker-compose.dev.yml up -d

--- a/nedrexdb/__init__.py
+++ b/nedrexdb/__init__.py
@@ -38,6 +38,7 @@ class _Config:
                                          'redis_queue_db': 3,
                                          'mongo_port_internal': 27017,
                                          'mongo_db': 'nedrexapi',
+                                         #'network': ,
                                          'node_collections': ['disorder',
                                                               'drug',
                                                               'gene',

--- a/nedrexdb/db/import_embeddings.py
+++ b/nedrexdb/db/import_embeddings.py
@@ -1,0 +1,64 @@
+from langchain_neo4j import Neo4jGraph
+from nedrexdb import config as _config
+import time
+
+# Define label and property key of embeddings
+LABEL = "Drug"
+EMBEDDING_PROPERTY = "embedding"
+ID_PROPERTY = "domainIds"  # or your unique node property
+
+
+def connect_to_session(session_type):
+    # Connection details
+    neo4j_container = _config[f"db.{session_type}.neo4j_name"]
+    bolt_port = 7687
+
+    NEO4J_URI = f'bolt://{neo4j_container}:{bolt_port}'
+
+    retry = 5
+    while retry > 0:
+        try:
+            kg = Neo4jGraph(
+                url=NEO4J_URI, username="", password="", database='neo4j'
+            )
+            break
+        except Exception:
+            retry -= 1
+            if retry == 0:
+                print("Could not connect to Neo4j database at " + NEO4J_URI)
+                return
+            time.sleep(5)
+    return kg
+
+
+
+def fetch_embeddings():
+    session = connect_to_session(session_type="live")
+    query = f"""
+    MATCH (n:{LABEL}) 
+    WHERE n.{EMBEDDING_PROPERTY} IS NOT NULL
+    RETURN n.{ID_PROPERTY} AS id, n.{EMBEDDING_PROPERTY} AS embedding
+    """
+    result = session.query(query)
+    return [(record["id"], record["embedding"]) for record in result]
+
+def upsert_embeddings(session, data):
+    query = f"""
+    UNWIND $nodes AS node
+    MERGE (n:{LABEL} {{ {ID_PROPERTY}: node.id }})
+    SET n.{EMBEDDING_PROPERTY} = node.embedding
+    """
+    session.run(query, nodes=[{"id": id_, "embedding": emb} for id_, emb in data])
+
+def main():
+    source_driver = GraphDatabase.driver(uri)
+    target_driver = GraphDatabase.driver(uri)
+
+    with source_driver.session() as source_session, target_driver.session() as target_session:
+        embeddings = fetch_embeddings(source_session)
+        print(f"Fetched {len(embeddings)} embeddings from source Neo4j.")
+        upsert_embeddings(target_session, embeddings)
+        print(f"Upserted embeddings into target Neo4j.")
+
+    source_driver.close()
+    target_driver.close()

--- a/nedrexdb/db/import_embeddings.py
+++ b/nedrexdb/db/import_embeddings.py
@@ -1,12 +1,11 @@
 from langchain_neo4j import Neo4jGraph
 from nedrexdb import config as _config
+from nedrexdb.post_integration.create_vector_indices import create_vector_index
+from nedrexdb.post_integration.embedding_config import NODE_EMBEDDING_CONFIG, EDGE_EMBEDDING_CONFIG
 import time
 
-# Define label and property key of embeddings
-LABEL = "Drug"
-EMBEDDING_PROPERTY = "embedding"
-ID_PROPERTY = "domainIds"  # or your unique node property
-
+node_keys = {key.lower(): key for key in NODE_EMBEDDING_CONFIG.keys()}
+edge_keys = {key.lower(): key for key in EDGE_EMBEDDING_CONFIG.keys()}
 
 def connect_to_session(session_type):
     # Connection details
@@ -31,25 +30,73 @@ def connect_to_session(session_type):
     return kg
 
 
-
-def fetch_embeddings():
+def fetch_embeddings(toimport_embeddings):
     session = connect_to_session(session_type="live")
-    query = f"""
-    MATCH (n:{LABEL}) 
-    WHERE n.{EMBEDDING_PROPERTY} IS NOT NULL
-    RETURN n.{ID_PROPERTY} AS id, n.{EMBEDDING_PROPERTY} AS embedding
-    """
-    result = session.query(query)
-    return [(record["id"], record["embedding"]) for record in result]
+    result = {}
+    for name in toimport_embeddings:
+        if name in node_keys.keys():
+            query = f"""
+            MATCH (n:{node_keys[name]}) 
+            WHERE n.embedding IS NOT NULL
+            RETURN n.primaryDomainId AS id, n.embedding AS embedding
+            """
+            query_result = session.query(query)
+            result[name] = [(record["id"], record["embedding"]) for record in query_result]
+        elif name in edge_keys.keys():
+            query = f"""
+                MATCH (src)-[r:{edge_keys[name]}]->(dst)
+                WHERE r.embedding IS NOT NULL
+                RETURN 
+                    src.primaryDomainId AS src_id,
+                    dst.primaryDomainId AS dst_id,
+                    r.embedding AS embedding
+                """
+            query_result = session.query(query)
+            result[name] = [
+                ((record["src_id"], record["dst_id"]), record["embedding"])
+                for record in query_result
+            ]
+        else:
+            print(f"Embedding {name} is not defined.")
 
-def upsert_embeddings(data):
+    return result
+
+
+def upsert_embeddings(embeddings):
     session = connect_to_session(session_type="dev")
-    query = f"""
-    UNWIND $nodes AS node
-    MERGE (n:{LABEL} {{ {ID_PROPERTY}: node.id }})
-    SET n.{EMBEDDING_PROPERTY} = node.embedding
-    """
-    session.query(
-        query,
-        {"nodes": [{"id": id_, "embedding": emb} for id_, emb in data]}
-    )
+    for name in embeddings:
+        if name in node_keys.keys():
+            create_vector_index(session, "NODE", node_keys[name])
+            query = f"""
+            UNWIND $nodes AS node
+            MERGE (n:{node_keys[name]} {{ primaryDomainId: node.id }})
+            SET n.embedding = node.embedding
+            """
+            session.query(
+                query,
+                {"nodes": [{"id": id_, "embedding": emb} for id_, emb in embeddings[name]]}
+            )
+        elif name in edge_keys.keys():
+            create_vector_index(session, "EDGE", edge_keys[name])
+            query = f"""
+                UNWIND $edges AS edge
+                MATCH (src {{ primaryDomainId: edge.src_id }})
+                MATCH (dst {{ primaryDomainId: edge.dst_id }})
+                MERGE (src)-[r:{edge_keys[name]}]->(dst)
+                SET r.embedding = edge.embedding
+                """
+            session.query(
+                query,
+                {
+                    "edges": [
+                        {
+                            "src_id": edge_id[0],  # unpack directly from tuple
+                            "dst_id": edge_id[1],
+                            "embedding": emb
+                        }
+                        for edge_id, emb in embeddings[name]
+                    ]
+                }
+            )
+        else:
+            print(f"Could not upsert Embedding {name}.")

--- a/nedrexdb/downloaders/__init__.py
+++ b/nedrexdb/downloaders/__init__.py
@@ -191,8 +191,11 @@ def update_versions(ignored_sources=set(), default_version=None):
             version = meta["version"] if "version" in meta.keys() else f"{date}"
             metadata["source_databases"][source] = {"date": f"{date}", "version": version}
 
+    try:
+        docs = list(MongoInstance.DB["metadata"].find())
+    except:
+        docs = []
 
-    docs = list(MongoInstance.DB["metadata"].find())
     if len(docs) == 1:
         version = docs[0]["version"]
     elif len(docs) == 0:
@@ -207,8 +210,7 @@ def update_versions(ignored_sources=set(), default_version=None):
 
     metadata["version"] = f"{v}"
 
-    MongoInstance.DB["metadata"].replace_one({}, metadata, upsert=True)
-
+    #MongoInstance.DB["metadata"].replace_one({}, metadata, upsert=True)
 
     return metadata
 
@@ -267,7 +269,8 @@ def get_versions(no_download):
         v.increment("patch")
         metadata["version"] = f"{v}"
 
-    for source in metadata["source_databases"].keys():
+    metadata_keys = {k for k in metadata["source_databases"].keys()}
+    for source in metadata_keys:
         if source not in _config["sources"]:
             del metadata["source_databases"][source]
 

--- a/nedrexdb/downloaders/__init__.py
+++ b/nedrexdb/downloaders/__init__.py
@@ -62,7 +62,7 @@ def update_version(name, source_url, unique_pattern, mode="date", skip_digits=0)
     print(f"{name}: date: {date}, version: {version}")
     return {"date": f"{date}", "version": version}
 
-def download_all(force=False, ignored_sources=set(), prev_metadata={}, current_metadata={}):
+def download_all(force=False, ignored_sources=set(), no_download_meta={}):
     base = _Path(_config["db.root_directory"])
     download_dir = base / _config["sources.directory"]
 
@@ -78,17 +78,13 @@ def download_all(force=False, ignored_sources=set(), prev_metadata={}, current_m
 
     print(f"ignore sources for download: {ignored_sources}")
 
-    # already up-to-date data
-    no_download = [key for key in prev_metadata if key in current_metadata and
-                   prev_metadata[key] == current_metadata[key]]
-
     if "chembl" not in ignored_sources:
-        if "chembl" not in no_download:
+        if "chembl" not in no_download_meta:
             _download_chembl()
         else:
             print("chembl is already up-to-date")
     if "biogrid" not in ignored_sources:
-        if "biogrid" not in no_download:
+        if "biogrid" not in no_download_meta:
             _download_biogrid()
         else:
             print("biogrid is already up-to-date")
@@ -110,7 +106,7 @@ def download_all(force=False, ignored_sources=set(), prev_metadata={}, current_m
             continue
 
         # only download if necessary (by checking previous metadata)
-        if source not in no_download:
+        if source not in no_download_meta:
             (download_dir / source).mkdir(exist_ok=True)
 
             data = sources[source]

--- a/nedrexdb/post_integration/create_vector_indices.py
+++ b/nedrexdb/post_integration/create_vector_indices.py
@@ -249,7 +249,10 @@ EDGE_EMBEDDING_CONFIG = {
 dev_nodes = None
 dev_edges = None
 
-def create_vector_indices():
+def create_vector_indices(tobuild=set()):
+    if not tobuild:
+        return
+
     neo4j_container = _config["db.dev.neo4j_name"]
     bolt_port = 7687
 

--- a/nedrexdb/post_integration/create_vector_indices.py
+++ b/nedrexdb/post_integration/create_vector_indices.py
@@ -1,257 +1,24 @@
 from langchain_neo4j import Neo4jGraph
 from nedrexdb import config as _config
 import time
+from nedrexdb.post_integration.embedding_config import NODE_EMBEDDING_CONFIG, EDGE_EMBEDDING_CONFIG
 
-NODE_EMBEDDING_CONFIG = {
-    "Disorder": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
-        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    },
-    "Gene": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "approvedSymbol": {"prefix": "Approved Symbol: ", "suffix": "", "type": "string"},
-        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
-        "geneType": {"prefix": "GeneType: ", "suffix": "", "type": "string"},
-        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
-        "symbols": {"prefix": "Alternative Symbols: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-    },
-    "Drug": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-        "casNumber": {"prefix": "This exact CAS number: ", "suffix": "", "type": "string"},
-    },
-    "Protein": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "geneName": {"prefix": "Gene name: ", "suffix": "", "type": "string"},
-        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-        "reviewed": {"prefix": "Review status: ", "suffix": "", "type": "boolean"},
-        "comments": {"prefix": "the following comments: ", "suffix": "", "type": "string"},
-    },
-    "GO": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
-        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    },
-    # "GenomicVariant": {
-    #     "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-    #     "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    #     "referenceSequence": {"prefix": "Reference Sequence: ", "suffix": "", "type": "string"},
-    #     "alternativeSequence": {"prefix": "Alternative Sequence: ", "suffix": "", "type": "string"},
-    #     "chromosome": {"prefix": "Chromosome: ", "suffix": "", "type": "string"},
-    #     "position": {"prefix": "Position: ", "suffix": "", "type": "string"},
-    #     "variantType": {"prefix": "Variant Type: ", "suffix": "", "type": "string"},
-    # },
-    "Pathway": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-        # "species": {"prefix": "Species: ", "suffix": "", "type": "string"},
-        # "taxid": {"prefix": "taxid: ", "suffix": "", "type": "string"},
-    },
-    "Phenotype": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
-        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    },
-    "SideEffect": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    },
-    "Signature": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-        # "database": {"prefix": "Database: ", "suffix": "", "type": "string"},
-    },
-    "Tissue": {
-        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
-        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
-        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
-    }
-}
-
-
-EDGE_EMBEDDING_CONFIG = {
-    "GeneAssociatedWithDisorder": {
-        "source": "Gene",
-        "link_term": "is associated with",
-        "target": "Disorder",
-        "attributes": {
-            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        }
-    },
-    "DrugHasIndication": {
-        "source": "Drug",
-        "link_term": "has an indication for",
-        "target": "Disorder",
-        "attributes": {
-            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        }
-    },
-    "DrugHasTarget": {
-        "source": "Drug",
-        "link_term": "has the known target",
-        "target": "Protein",
-        "attributes": {
-            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        }
-    },
-    "DisorderHasPhenotype": {
-        "source": "Disorder",
-        "link_term": "exhibits the known phenotype",
-        "target": "Phenotype",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    },
-    "DisorderIsSubtypeOfDisorder": {
-        "source": "Disorder",
-        "link_term": "is subtype of",
-        "target": "Disorder",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    },
-    "DrugHasContraindication": {
-        "source": "Drug",
-        "link_term": "is contraindicated in",
-        "target": "Disorder",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    },
-    "DrugHasSideEffect": {
-        "source": "Drug",
-        "link_term": "has the known side effect",
-        "target": "SideEffect",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-        #     "maximum_frequency": {"prefix": "Maximum Frequency: ", "suffix": "", "type": "string"},
-        #     "minimum_frequency": {"prefix": "Minimum Frequency: ", "suffix": "", "type": "string"}
-        # }
-    },
-    # "GOIsSubtypeOfGO": {
-    #     "source": "GO",
-    #     "link_term": "is subtype of",
-    #     "target": "GO",
-    #     "attributes": {
-    #         "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-    #     }
-    # },
-    "GeneExpressedInTissue": {
-        "source": "Gene",
-        "link_term": "is expressed in",
-        "target": "Tissue",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-            # "TPM": {"prefix": "TPM: ", "suffix": "", "type": "string"},
-            # "nTPM": {"prefix": "nTPM: ", "suffix": "", "type": "string"},
-            # "pTPM": {"prefix": "pTPM: ", "suffix": "", "type": "string"},
-        # }
-    },
-    "ProteinEncodedByGene": {
-        "source": "Protein",
-        "link_term": "is encoded by",
-        "target": "Gene",
-        "attributes": {
-            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        }
-    },
-    # "ProteinExpressedInTissue": {
-    #     "source": "Protein",
-    #     "link_term": "is expressed by",
-    #     "target": "Tissue",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-            # "level": {"prefix": "Expression level: ", "suffix": "", "type": "string"},
-        # }
-    # },
-    "ProteinHasGoAnnotation": {
-        "source": "Protein",
-        "link_term": "has GO annotation",
-        "target": "GO",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-        #     "qualifiers": {"prefix": "Qualifiers: ", "suffix": "", "type": "list"},
-        # }
-    },
-    # "ProteinHasSignature": {
-    #     "source": "Protein",
-    #     "link_term": "has signature",
-    #     "target": "Signature",
-    #     "attributes": {
-    #         "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-    #     }
-    # },
-    # "ProteinInPathway": {
-    #     "source": "Protein",
-    #     "link_term": "is in the pathway",
-    #     "target": "Pathway",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    # },
-    # "ProteinInteractsWithProtein": {
-    #     "source": "Protein",
-    #     "link_term": "interacts with",
-    #     "target": "Protein",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-        #     "evidenceTypes": {"prefix": "Evidence Type: ", "suffix": "", "type": "list"},
-        #     "methods": {"prefix": "Method/Approach: ", "suffix": "", "type": "list"},
-        #     "subcellularLocations": {"prefix": "Subcellular Locations: ", "suffix": "", "type": "list"},
-        #     "tissues": {"prefix": "Tissues: ", "suffix": "", "type": "list"},
-        # }
-    # },
-    "SideEffectSameAsPhenotype": {
-        "source": "SideEffect",
-        "link_term": "is the same as",
-        "target": "Phenotype",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    },
-    # "VariantAffectsGene": {
-    #     "source": "GenomicVariant",
-    #     "link_term": "effects",
-    #     "target": "Gene",
-        # "attributes": {
-        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
-        # }
-    # },
-    "VariantAssociatedWithDisorder": {
-        "source": "GenomicVariant",
-        "link_term": "is associated with",
-        "target": "Disorder",
-        # "attributes": {
-        #     # "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
-        #     "effects": {"prefix": "Effects: ", "suffix": "", "type": "list"},
-        #     # "accession": {"prefix": "Accession: ", "suffix": "", "type": "string"},
-        #     "reviewStatus": {"prefix": "Review Status: ", "suffix": "", "type": "string"}
-        # }
-    },
-}
-
-# only building embeddings for dev nodes and edges, except they are None.
-dev_nodes = None
-dev_edges = None
+node_keys = {key.lower(): key for key in NODE_EMBEDDING_CONFIG.keys()}
+edge_keys = {key.lower(): key for key in EDGE_EMBEDDING_CONFIG.keys()}
 
 def create_vector_indices(tobuild=set()):
     if not tobuild:
         return
+
+    # only building embeddings for dev nodes and edges, except they are None.
+    dev_nodes = []
+    dev_edges = []
+
+    for embedding in tobuild:
+        if embedding in node_keys:
+            dev_nodes.append(node_keys[embedding])
+        elif embedding in edge_keys:
+            dev_edges.append(edge_keys[embedding])
 
     neo4j_container = _config["db.dev.neo4j_name"]
     bolt_port = 7687
@@ -336,7 +103,7 @@ def get_edge_info_string(edge_name):
     return info_string
 
 def fill_vector_index(con, entityType, name):
-
+    retries = 5
     try:
         start = time.time()
         create_vector_index(con, entityType, name)
@@ -345,13 +112,22 @@ def fill_vector_index(con, entityType, name):
         if entityType == "NODE":
             info_string = get_node_info_string(name)
             query = create_node_vector_query(info_string, name)
-            con.query(query, params=params)
         else:
             info_string = get_edge_info_string(name)
             source_name = EDGE_EMBEDDING_CONFIG[name]["source"]
             target_name = EDGE_EMBEDDING_CONFIG[name]["target"]
             query = create_edge_vector_query(info_string, source_name, name, target_name)
-            con.query(query, params=params)
+        while retries > 0:
+            retries -=1
+            try:
+                con.query(query, params=params)
+                break
+            except Exception as e:
+                print(e)
+                print(f"Encountered an issue! Retry {6-retries} retrying in 60s...")
+                if retries == 0:
+                    raise e
+                time.sleep(60)
         duration = time.time() - start
         print(f"Building {name} embedding indexes finished after {duration} seconds")
     except Exception as e:

--- a/nedrexdb/post_integration/embedding_config.py
+++ b/nedrexdb/post_integration/embedding_config.py
@@ -1,0 +1,242 @@
+NODE_EMBEDDING_CONFIG = {
+    "Disorder": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
+        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    },
+    "Gene": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "approvedSymbol": {"prefix": "Approved Symbol: ", "suffix": "", "type": "string"},
+        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
+        "geneType": {"prefix": "GeneType: ", "suffix": "", "type": "string"},
+        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
+        "symbols": {"prefix": "Alternative Symbols: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+    },
+    "Drug": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+        "casNumber": {"prefix": "This exact CAS number: ", "suffix": "", "type": "string"},
+    },
+    "Protein": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "geneName": {"prefix": "Gene name: ", "suffix": "", "type": "string"},
+        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+        "reviewed": {"prefix": "Review status: ", "suffix": "", "type": "boolean"},
+        "comments": {"prefix": "the following comments: ", "suffix": "", "type": "string"},
+    },
+    "GO": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
+        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    },
+    # "GenomicVariant": {
+    #     "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+    #     "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    #     "referenceSequence": {"prefix": "Reference Sequence: ", "suffix": "", "type": "string"},
+    #     "alternativeSequence": {"prefix": "Alternative Sequence: ", "suffix": "", "type": "string"},
+    #     "chromosome": {"prefix": "Chromosome: ", "suffix": "", "type": "string"},
+    #     "position": {"prefix": "Position: ", "suffix": "", "type": "string"},
+    #     "variantType": {"prefix": "Variant Type: ", "suffix": "", "type": "string"},
+    # },
+    "Pathway": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+        # "species": {"prefix": "Species: ", "suffix": "", "type": "string"},
+        # "taxid": {"prefix": "taxid: ", "suffix": "", "type": "string"},
+    },
+    "Phenotype": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "synonyms": {"prefix": "Synonyms: ", "suffix": "", "type": "list"},
+        "description": {"prefix": "Description: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    },
+    "SideEffect": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    },
+    "Signature": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+        # "database": {"prefix": "Database: ", "suffix": "", "type": "string"},
+    },
+    "Tissue": {
+        "displayName": {"prefix": "DisplayName: ", "suffix": "", "type": "string"},
+        "domainIds": {"prefix": "Other used IDs: ", "suffix": "", "type": "list"},
+        # "dataSources": {"prefix": "Data Sources: ", "suffix": "", "type": "list"},
+    }
+}
+
+
+EDGE_EMBEDDING_CONFIG = {
+    "GeneAssociatedWithDisorder": {
+        "source": "Gene",
+        "link_term": "is associated with",
+        "target": "Disorder",
+        "attributes": {
+            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        }
+    },
+    "DrugHasIndication": {
+        "source": "Drug",
+        "link_term": "has an indication for",
+        "target": "Disorder",
+        "attributes": {
+            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        }
+    },
+    "DrugHasTarget": {
+        "source": "Drug",
+        "link_term": "has the known target",
+        "target": "Protein",
+        "attributes": {
+            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        }
+    },
+    "DisorderHasPhenotype": {
+        "source": "Disorder",
+        "link_term": "exhibits the known phenotype",
+        "target": "Phenotype",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    },
+    "DisorderIsSubtypeOfDisorder": {
+        "source": "Disorder",
+        "link_term": "is subtype of",
+        "target": "Disorder",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    },
+    "DrugHasContraindication": {
+        "source": "Drug",
+        "link_term": "is contraindicated in",
+        "target": "Disorder",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    },
+    "DrugHasSideEffect": {
+        "source": "Drug",
+        "link_term": "has the known side effect",
+        "target": "SideEffect",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+        #     "maximum_frequency": {"prefix": "Maximum Frequency: ", "suffix": "", "type": "string"},
+        #     "minimum_frequency": {"prefix": "Minimum Frequency: ", "suffix": "", "type": "string"}
+        # }
+    },
+    # "GOIsSubtypeOfGO": {
+    #     "source": "GO",
+    #     "link_term": "is subtype of",
+    #     "target": "GO",
+    #     "attributes": {
+    #         "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+    #     }
+    # },
+    "GeneExpressedInTissue": {
+        "source": "Gene",
+        "link_term": "is expressed in",
+        "target": "Tissue",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+            # "TPM": {"prefix": "TPM: ", "suffix": "", "type": "string"},
+            # "nTPM": {"prefix": "nTPM: ", "suffix": "", "type": "string"},
+            # "pTPM": {"prefix": "pTPM: ", "suffix": "", "type": "string"},
+        # }
+    },
+    "ProteinEncodedByGene": {
+        "source": "Protein",
+        "link_term": "is encoded by",
+        "target": "Gene",
+        "attributes": {
+            "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        }
+    },
+    # "ProteinExpressedInTissue": {
+    #     "source": "Protein",
+    #     "link_term": "is expressed by",
+    #     "target": "Tissue",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+            # "level": {"prefix": "Expression level: ", "suffix": "", "type": "string"},
+        # }
+    # },
+    "ProteinHasGoAnnotation": {
+        "source": "Protein",
+        "link_term": "has GO annotation",
+        "target": "GO",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+        #     "qualifiers": {"prefix": "Qualifiers: ", "suffix": "", "type": "list"},
+        # }
+    },
+    # "ProteinHasSignature": {
+    #     "source": "Protein",
+    #     "link_term": "has signature",
+    #     "target": "Signature",
+    #     "attributes": {
+    #         "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+    #     }
+    # },
+    # "ProteinInPathway": {
+    #     "source": "Protein",
+    #     "link_term": "is in the pathway",
+    #     "target": "Pathway",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    # },
+    # "ProteinInteractsWithProtein": {
+    #     "source": "Protein",
+    #     "link_term": "interacts with",
+    #     "target": "Protein",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+        #     "evidenceTypes": {"prefix": "Evidence Type: ", "suffix": "", "type": "list"},
+        #     "methods": {"prefix": "Method/Approach: ", "suffix": "", "type": "list"},
+        #     "subcellularLocations": {"prefix": "Subcellular Locations: ", "suffix": "", "type": "list"},
+        #     "tissues": {"prefix": "Tissues: ", "suffix": "", "type": "list"},
+        # }
+    # },
+    "SideEffectSameAsPhenotype": {
+        "source": "SideEffect",
+        "link_term": "is the same as",
+        "target": "Phenotype",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    },
+    # "VariantAffectsGene": {
+    #     "source": "GenomicVariant",
+    #     "link_term": "effects",
+    #     "target": "Gene",
+        # "attributes": {
+        #     "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"}
+        # }
+    # },
+    "VariantAssociatedWithDisorder": {
+        "source": "GenomicVariant",
+        "link_term": "is associated with",
+        "target": "Disorder",
+        # "attributes": {
+        #     # "dataSources": {"prefix": "Data Source: ", "suffix": "", "type": "list"},
+        #     "effects": {"prefix": "Effects: ", "suffix": "", "type": "list"},
+        #     # "accession": {"prefix": "Accession: ", "suffix": "", "type": "string"},
+        #     "reviewStatus": {"prefix": "Review Status: ", "suffix": "", "type": "string"}
+        # }
+    },
+}

--- a/setup_data.sh
+++ b/setup_data.sh
@@ -9,7 +9,7 @@ wget https://cloud.uni-hamburg.de/s/RiAtjZC3bb7bg7n/download/bioontology.zip -q 
 echo "Downloaded bioontology.zip"
 wget https://cloud.uni-hamburg.de/s/5meqDbTbgydo6Tj/download/drugbank.zip -q -O drugbank.zip
 echo "Downloaded drugbank.zip"
-wget https://cloud.uni-hamburg.de/s/CwfdZ5AHFcEckRF/download/disgenet.zip -q -O disgenet.zip
+wget https://cloud.uni-hamburg.de/public.php/dav/files/9wNb5HWL7RBH6ng/?accept=zip -q -O disgenet.zip
 echo "Downloaded disgenet.zip"
 wget https://cloud.uni-hamburg.de/s/PxWXAMY5bfS3ZcA/download/repotrial.zip -q -O repotrial.zip
 echo "Downloaded repotrial.zip"


### PR DESCRIPTION
Saves build time & gives user more control. 
Decide which embeddings should be included in the latest build via config
configure possible embeddings in embedding_config.py
metadata & dataSources match, embedding is imported from last version instead of being built from scratch now - saves a lot time, especially for static sources or weekly builds